### PR TITLE
feat: Enhance session and cookie management security

### DIFF
--- a/catalog/cookie.tpl
+++ b/catalog/cookie.tpl
@@ -1,0 +1,92 @@
+<?php
+class CookieManager {
+
+    /**
+     * Sets a cookie with secure defaults.
+     *
+     * @param string $name The name of the cookie.
+     * @param string $value The value of the cookie. Default is an empty string.
+     * @param int $expires The time the cookie expires. This is a Unix timestamp, so time() + seconds is typical. Default is 0 (session cookie).
+     * @param string $path The path on the server in which the cookie will be available on. Default is '/'.
+     * @param string $domain The (sub)domain that the cookie is available to. Default is empty string (current host).
+     * @param bool|null $secure Indicates that the cookie should only be transmitted over a secure HTTPS connection.
+     *                          Defaults to null, which means it will be true if HTTPS is used, false otherwise.
+     * @param bool $httpOnly When TRUE the cookie will be made accessible only through the HTTP protocol.
+     *                       This means that the cookie won't be accessible by scripting languages, such as JavaScript. Default is true.
+     * @param string $sameSite ('Lax', 'Strict', 'None') Asserts that a cookie must not be sent with cross-origin requests. 'Lax' is a good default.
+     *                         If 'None', the 'Secure' attribute must also be set.
+     */
+    public static function set(
+        string $name,
+        string $value = "",
+        int $expires = 0,
+        string $path = "/",
+        string $domain = "",
+        bool $secure = null,
+        bool $httpOnly = true,
+        string $sameSite = 'Lax'
+    ) {
+        if ($secure === null) {
+            $secure = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on';
+        }
+
+        if (strtolower($sameSite) === 'none' && !$secure) {
+            // Warning or error: SameSite=None requires Secure attribute
+            // For simplicity here, we won't set the cookie if this condition is violated,
+            // or one could default SameSite to 'Lax'.
+            // Let's log an error and not set the cookie to highlight the issue.
+            error_log("CookieManager Error: Setting a cookie with SameSite=None requires the Secure attribute to be set. Cookie '{$name}' not set.");
+            return;
+        }
+        
+        // PHP 7.3+ allows setting SameSite directly in $options array
+        if (PHP_VERSION_ID >= 70300) {
+            $options = [
+                'expires' => $expires,
+                'path' => $path,
+                'domain' => $domain,
+                'secure' => $secure,
+                'httponly' => $httpOnly,
+                'samesite' => $sameSite,
+            ];
+            setcookie($name, $value, $options);
+        } else {
+            // For PHP < 7.3, SameSite must be appended to path if needed.
+            // This is a simplified approach; full SameSite support for older PHP is more complex.
+            $pathWithSameSite = $path . (empty($sameSite) ? '' : '; samesite=' . $sameSite);
+            setcookie($name, $value, $expires, $pathWithSameSite, $domain, $secure, $httpOnly);
+        }
+    }
+
+    /**
+     * Gets a cookie value.
+     *
+     * @param string $name The name of the cookie.
+     * @return string|null The value of the cookie, or null if not found.
+     */
+    public static function get(string $name) {
+        return $_COOKIE[$name] ?? null;
+    }
+
+    /**
+     * Deletes a cookie.
+     *
+     * @param string $name The name of the cookie to delete.
+     * @param string $path The path of the cookie.
+     * @param string $domain The domain of the cookie.
+     */
+    public static function delete(string $name, string $path = "/", string $domain = "") {
+        // Set expiry to one hour in the past
+        // Secure and HttpOnly flags should ideally also match the set cookie to ensure deletion.
+        // For this simplified version, we just expire it.
+        // The 'secure' and 'httponly' parameters for deletion should match how the cookie was set.
+        // However, PHP's setcookie for deletion primarily relies on name, path, domain, and past expiry.
+        if (isset($_COOKIE[$name])) {
+             // To ensure deletion, set value to empty and expiry in the past.
+             // Path and domain must match how the cookie was set.
+            self::set($name, "", time() - 3600, $path, $domain); // Uses the secure defaults of self::set()
+            unset($_COOKIE[$name]); // Also unset from current request's $_COOKIE array
+        }
+    }
+}
+?>

--- a/catalog/session.tpl
+++ b/catalog/session.tpl
@@ -2,7 +2,17 @@
 class session{
 
     public static function start(){
-        ini_set('session.cookie_httponly',true);
+        $cookieParams = [
+            'lifetime' => TIMEOUT, // From config.tpl
+            'path' => '/',
+            'domain' => '', // Defaults to current host
+            'secure' => isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on',
+            'httponly' => true,
+            'samesite' => 'Lax' // Good default for SameSite
+        ];
+        session_set_cookie_params($cookieParams);
+
+        ini_set('session.cookie_httponly', true); // Can be kept
         session_start();
 
         if(!isset($_SESSION['IP']))
@@ -24,6 +34,17 @@ class session{
 			unset($_SESSION['UA']);
             unset($_SESSION['IP']);
             header('Location: '.ADMIN_PATH.'?RID=102');
+        }
+    }
+
+    /**
+     * Regenerates the session ID to help prevent session fixation.
+     * This should be called after any significant authentication state change,
+     * such as user login.
+     */
+    public static function regenerate() {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_regenerate_id(true); // true to delete old session file
         }
     }
 

--- a/config.tpl
+++ b/config.tpl
@@ -50,6 +50,7 @@
     require_once VIEW. "CoreEssentials.tpl"; // Replaced htmlEssentials with CoreEssentials
     require_once CATALOG.'validation.tpl';
     require_once CATALOG."Validator.tpl"; // Added Validator
+    require_once CATALOG."cookie.tpl"; // Added CookieManager
     require_once DBASE.'dbContext.tpl';
     require_once CATALOG.'functions.tpl';
 


### PR DESCRIPTION
This commit introduces significant security improvements to session handling and adds a new utility for managing cookies with secure defaults.

Key changes:
- Enhanced `catalog/session.tpl`:
    - The `session::start()` method now calls `session_set_cookie_params()` before `session_start()` to enforce HttpOnly, Secure (if HTTPS), and SameSite=Lax attributes for session cookies.
    - Added a new public static method `session::regenerate()` to allow explicit regeneration of the session ID (e.g., after login) to help prevent session fixation.
- Created `catalog/cookie.tpl`:
    - Introduced a new `CookieManager` class with static methods: - `set()`: Sets cookies with secure defaults (HttpOnly, Secure, SameSite=Lax, path='/'). Handles PHP version differences for SameSite attribute. - `get()`: Retrieves cookie values. - `delete()`: Deletes cookies by expiring them.
- Updated `config.tpl` to include `catalog/cookie.tpl`, making `CookieManager` globally available.

These changes provide a more secure foundation for managing your sessions and application cookies.