### PR TITLE
refactor(Phase2B): Introduce web controllers and update router dispatch

### DIFF
--- a/Admin/index.php
+++ b/Admin/index.php
@@ -12,6 +12,6 @@
       // 3. Default title: "Login" (as per previous adminRouting logic for root access)
       // 4. Standalone routes: [] (adminRouting didn't have special standalone logic like the main site's Login)
       // CoreEssentials (now ViewManager) is autoloaded via App\Core namespace
-      // modulePath="admin"
-      $app = new \App\Core\CoreRouter("admin", "__Admin__", "index", "Login", []); // Use FQN, added modulePath
+      // modulePath="Admin", templateNamePrefix="__Admin__", defaultControllerName="Auth", defaultMethodName="index"
+      $app = new \App\Core\CoreRouter("Admin", "__Admin__", "Auth", "index"); // Use FQN, updated for new constructor
 ?>

--- a/app/Controller/Admin/AuthController.php
+++ b/app/Controller/Admin/AuthController.php
@@ -1,0 +1,19 @@
+<?php
+namespace App\Controller\Admin;
+
+use App\Core\ViewManager;
+
+class AuthController {
+    private $viewManager;
+
+    public function __construct(ViewManager $viewManager) {
+        $this->viewManager = $viewManager;
+    }
+
+    public function index() {
+        // Admin login page, typically standalone
+        // This uses view/admin/index.tpl as the login page view
+        $this->viewManager->body('admin/index', 'Admin Portal Login', null, true);
+    }
+}
+?>

--- a/app/Controller/Public/HomeController.php
+++ b/app/Controller/Public/HomeController.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Controller\Public;
+
+use App\Core\ViewManager; // Use statement for ViewManager
+
+class HomeController {
+    private $viewManager;
+
+    public function __construct(ViewManager $viewManager) {
+        $this->viewManager = $viewManager;
+    }
+
+    public function index() {
+        // Parameters for ViewManager->body: viewPath, title, args, noInclude
+        $this->viewManager->body('public/index', 'Welcome Home', null, false);
+    }
+}
+?>

--- a/app/Controller/Public/LoginController.php
+++ b/app/Controller/Public/LoginController.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Controller\Public;
+
+use App\Core\ViewManager;
+
+class LoginController {
+    private $viewManager;
+
+    public function __construct(ViewManager $viewManager) {
+        $this->viewManager = $viewManager;
+    }
+
+    public function index() {
+        // Assuming 'public/login' view is standalone (no main header/footer)
+        $this->viewManager->body('public/login', 'Login', null, true);
+    }
+}
+?>

--- a/app/Core/CoreRouter.php
+++ b/app/Core/CoreRouter.php
@@ -1,35 +1,36 @@
 <?php
 namespace App\Core;
 
-// CoreEssentials class (now ViewManager) is expected to be available via autoloader.
+// ViewManager class is expected to be available via autoloader.
 class CoreRouter {
-    private $modulePath; // Added modulePath property
+    private $modulePath; 
     private $templateNamePrefix; 
-    private $defaultViewName;
-    private $defaultTitle;
-    private $standaloneRoutes;
-    private $essentialsInstance; // Should now be an instance of ViewManager
+    private $defaultControllerName; // New property
+    private $defaultMethodName;     // New property
+    // private $defaultViewName;    // Removed
+    // private $defaultTitle;       // Removed
+    // private $standaloneRoutes;   // Removed
+    private $essentialsInstance; // Instance of ViewManager
 
     public function __construct(
-        string $modulePath, // Added modulePath parameter
+        string $modulePath, 
         string $templateNamePrefix, 
-        string $defaultViewName,
-        string $defaultTitle,
-        array $standaloneRoutes = []
+        string $defaultControllerName, // New parameter
+        string $defaultMethodName = 'index' // New parameter with default
     ) {
-        $this->modulePath = $modulePath; // Assign modulePath
+        $this->modulePath = $modulePath; 
         $this->templateNamePrefix = $templateNamePrefix; 
-        $this->defaultViewName = $defaultViewName;
-        $this->defaultTitle = $defaultTitle;
-        $this->standaloneRoutes = $standaloneRoutes;
+        $this->defaultControllerName = $defaultControllerName; // Assign new property
+        $this->defaultMethodName = $defaultMethodName;       // Assign new property
 
         // ViewManager is expected to be included/available via autoloader.
-        if (!class_exists("\\App\\Core\\ViewManager")) { // Updated class name check
+        if (!class_exists("\\App\\Core\\ViewManager")) { 
             error_log("CoreRouter Error: View manager class '\\App\\Core\\ViewManager' not found. Make sure app/Core/ViewManager.php is available and autoloadable.");
+            // Potentially throw an exception or handle more gracefully
             return; 
         }
         // Instantiate ViewManager, passing the template name prefix
-        $this->essentialsInstance = new \App\Core\ViewManager($this->templateNamePrefix); // Updated instantiation
+        $this->essentialsInstance = new \App\Core\ViewManager($this->templateNamePrefix); 
 
         $this->route();
     }
@@ -37,38 +38,48 @@ class CoreRouter {
     private function route() {
         $url = (isset($_GET['url'])) ? $_GET['url'] : false;
         $url = rtrim($url, "/");
-        $url = ($url === false || $url === "") ? [] : explode("/", $url);
+        $url = ($url === false || $url === "") ? [] : explode("/", $url); // Ensure $url is always an array
 
-        $actualViewNamePart = ''; // The part like "index" or "login" or $url[0]
-        $title = '';
-        $argument = '';
-        $isStandalonePage = false;
+        $controllerName = ucfirst(strtolower($url[0] ?? $this->defaultControllerName));
+        // Ensure modulePath (e.g., "Public", "Admin") is correctly cased for namespace
+        $moduleNamespacePart = ucfirst(strtolower($this->modulePath)); 
+        $controllerClassName = "App\\Controller\\" . $moduleNamespacePart . "\\" . $controllerName . "Controller";
 
-        if (empty($url[0])) { // No URL or root access
-            $actualViewNamePart = $this->defaultViewName;
-            $title = $this->defaultTitle;
-            $isStandalonePage = in_array($this->defaultViewName, $this->standaloneRoutes);
-            // $argument remains empty
+        // Determine method name
+        if (isset($url[1]) && !empty($url[1])) {
+            $methodName = $url[1]; // Use method name from URL if present
         } else {
-            $actualViewNamePart = $url[0];
-            $title = $url[0]; // Title usually matches controller/view name
-            $isStandalonePage = in_array($actualViewNamePart, $this->standaloneRoutes);
-
-            if (isset($url[1])) {
-                $argument = $url[1];
-            }
+            $methodName = $this->defaultMethodName; // Default to 'index' or specified default
         }
 
-        $viewPathForViewManager = $this->modulePath . '/' . $actualViewNamePart;
-        
-        if ($this->essentialsInstance && method_exists($this->essentialsInstance, 'body')) {
-            $this->essentialsInstance->body($viewPathForViewManager, $title, $argument, $isStandalonePage); // Pass updated view path
-        } else {
-            if (!$this->essentialsInstance) {
-                 error_log("CoreRouter Error: Essentials instance of '\\App\\Core\\ViewManager' was not created (likely class not found). Cannot call 'body'."); // Updated error message
+        $arguments = array_slice($url, 2);
+
+        if (class_exists($controllerClassName)) {
+            $controllerInstance = new $controllerClassName($this->essentialsInstance); // Pass ViewManager
+
+            if (method_exists($controllerInstance, $methodName)) {
+                call_user_func_array([$controllerInstance, $methodName], $arguments);
             } else {
-                 error_log("CoreRouter Error: Method 'body' not found in class '\\App\\Core\\ViewManager'."); // Updated error message
+                // Method not found - 404
+                error_log("CoreRouter Error: Method '{$methodName}' not found in controller '{$controllerClassName}'.");
+                if ($this->essentialsInstance && method_exists($this->essentialsInstance, 'body')) {
+                     $this->essentialsInstance->body($this->modulePath . '/404', 'Page Not Found', null, true);
+                } else {
+                    header("HTTP/1.0 404 Not Found");
+                    echo "<h1>404 - Page Not Found (Error: Unable to load error view)</h1>";
+                }
+                exit;
             }
+        } else {
+            // Controller class not found - 404
+            error_log("CoreRouter Error: Controller class '{$controllerClassName}' not found for module '{$this->modulePath}' and controller part '{$controllerName}'.");
+            if ($this->essentialsInstance && method_exists($this->essentialsInstance, 'body')) {
+                 $this->essentialsInstance->body($this->modulePath . '/404', 'Page Not Found', null, true);
+            } else {
+                header("HTTP/1.0 404 Not Found");
+                echo "<h1>404 - Page Not Found (Error: Unable to load error view)</h1>";
+            }
+            exit;
         }
     }
 }

--- a/index.php
+++ b/index.php
@@ -21,7 +21,7 @@
           // CoreEssentials (now ViewManager) is autoloaded via App\Core namespace
           // "index" is the default view/title. "Login" is a standalone page.
           // The templateNamePrefix for the main site is an empty string.
-          // modulePath="public"
-          $app = new \App\Core\CoreRouter("public", "", "index", "index", ["Login"]); // Use FQN, added modulePath
+          // modulePath="Public", templateNamePrefix="", defaultControllerName="Home", defaultMethodName="index"
+          $app = new \App\Core\CoreRouter("Public", "", "Home", "index"); // Use FQN, updated for new constructor
       }
 ?>

--- a/view/admin/404.tpl
+++ b/view/admin/404.tpl
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>404 - Page Not Found (Admin)</title>
+</head>
+<body>
+    <h1>404 - Page Not Found (Admin)</h1>
+    <p>The admin page or resource you requested could not be found.</p>
+</body>
+</html>

--- a/view/public/404.tpl
+++ b/view/public/404.tpl
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>404 - Page Not Found</title>
+</head>
+<body>
+    <h1>404 - Page Not Found</h1>
+    <p>The page you requested could not be found.</p>
+</body>
+</html>

--- a/view/public/login.tpl
+++ b/view/public/login.tpl
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title><?php echo isset($title) ? esc_html($title) : 'Login'; ?></title>
+    <?php // This view is rendered as standalone by LoginController, 
+          // so it won't use the main __Header.tpl unless explicitly included here.
+          // For a true standalone page, you might have specific CSS links here.
+    ?>
+    <style>
+        body { font-family: sans-serif; margin: 40px; background-color: #f4f4f4; }
+        .container { background-color: #fff; padding: 20px; border-radius: 5px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        label { display: block; margin-bottom: 8px; }
+        input[type="text"], input[type="password"] { width: 100%; padding: 10px; margin-bottom: 15px; border: 1px solid #ddd; border-radius: 3px; box-sizing: border-box; }
+        button { background-color: #007bff; color: white; padding: 10px 15px; border: none; border-radius: 3px; cursor: pointer; }
+        button:hover { background-color: #0056b3; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Login</h1>
+        <form action="<?php echo WEBPATH; ?>login/process" method="POST"> <?php // Action URL is placeholder ?>
+            <div>
+                <label for="username">Username:</label>
+                <input type="text" id="username" name="username" required>
+            </div>
+            <div>
+                <label for="password">Password:</label>
+                <input type="password" id="password" name="password" required>
+            </div>
+            <button type="submit">Login</button>
+        </form>
+        <?php if(isset($arg) && !empty($arg)): ?>
+            <p style="color:red;">Error: <?php echo esc_html($arg); ?></p>
+        <?php endif; ?>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This commit implements Part B of Phase 2 of the major architectural refactoring, introducing dedicated web controllers and updating the CoreRouter to dispatch requests to controller methods.

Key changes:
- Created initial web controllers with ViewManager injection:
    - `App\Controller\Public\HomeController` (handles default public route)
    - `App\Controller\Public\LoginController` (handles /Login route)
    - `App\Controller\Admin\AuthController` (handles default admin route)
- Refactored `App\Core\CoreRouter`:
    - Constructor now accepts default controller and method names.
    - `route()` method now resolves controller class and method from URL (or defaults), instantiates the controller (injecting ViewManager), and calls the appropriate method.
    - Implemented 404 error handling that attempts to render module-specific 404 views (e.g., `view/public/404.tpl`, `view/admin/404.tpl`).
- Created placeholder view files: `view/public/login.tpl`, `view/public/404.tpl`, and `view/admin/404.tpl`.
- Updated `index.php` (root) and `Admin/index.php` to instantiate `CoreRouter` with new parameters for default controller and method.

This change moves towards a more standard MVC pattern by having dedicated controllers handle web requests, rather than the router directly managing view rendering.