### PR TITLE
refactor(Phase3): Introduce service layer for accounts API

### DIFF
--- a/app/Interfaces/Service/IAccountService.php
+++ b/app/Interfaces/Service/IAccountService.php
@@ -1,0 +1,29 @@
+<?php
+namespace App\Interfaces\Service;
+
+interface IAccountService {
+    /**
+     * Retrieves all accounts.
+     *
+     * @return array An array of all accounts. Empty array if none.
+     */
+    public function getAllAccounts(): array;
+
+    /**
+     * Retrieves a specific account by its ID.
+     *
+     * @param int $id The ID of the account.
+     * @return array|null The account data as an array, or null if not found.
+     */
+    public function getAccountById(int $id): ?array;
+
+    /**
+     * Creates a new account.
+     *
+     * @param array $data Associative array containing account data (e.g., ['name' => ..., 'email' => ...]).
+     *                    Assumes data is already validated.
+     * @return int|null The ID of the newly created account, or null on failure.
+     */
+    public function createAccount(array $data): ?int;
+}
+?>

--- a/app/Service/AccountService.php
+++ b/app/Service/AccountService.php
@@ -1,0 +1,70 @@
+<?php
+namespace App\Service;
+
+use App\Interfaces\Service\IAccountService;
+use App\Persistence\DbContext;
+
+class AccountService implements IAccountService {
+    private $db;
+
+    public function __construct(DbContext $db) {
+        $this->db = $db;
+    }
+
+    /**
+     * Retrieves all accounts.
+     *
+     * @return array An array of all accounts. Empty array if none.
+     */
+    public function getAllAccounts(): array {
+        // Assuming DbContext::select returns null on error/no results, or an array of rows.
+        $accounts = $this->db->select("SELECT id, name, email FROM accounts");
+        return $accounts ?? []; // Ensure array return type
+    }
+
+    /**
+     * Retrieves a specific account by its ID.
+     *
+     * @param int $id The ID of the account.
+     * @return array|null The account data as an array, or null if not found.
+     */
+    public function getAccountById(int $id): ?array {
+        // DbContext::select is expected to return an array of rows.
+        // If a single row is found, it will be the first element of that array.
+        $result = $this->db->select("SELECT id, name, email FROM accounts WHERE id = ?", [$id]);
+        if (!empty($result)) {
+            return $result[0]; // Return the first (and should be only) row
+        }
+        return null;
+    }
+
+    /**
+     * Creates a new account.
+     *
+     * @param array $data Associative array containing account data (e.g., ['name' => ..., 'email' => ...]).
+     *                    Assumes data is already validated by the controller/caller.
+     * @return int|null The ID of the newly created account, or null on failure.
+     */
+    public function createAccount(array $data): ?int {
+        // Ensure 'name' and 'email' keys exist in $data, though controller should validate this.
+        // This is a service layer; primary validation should occur before calling this.
+        if (!isset($data['name']) || !isset($data['email'])) {
+            // Or throw an InvalidArgumentException
+            error_log("AccountService::createAccount Error: Missing name or email in data array.");
+            return null; 
+        }
+
+        $success = $this->db->insert(
+            "INSERT INTO accounts (name, email) VALUES (?, ?)",
+            [$data['name'], $data['email']]
+        );
+
+        if ($success) {
+            // DbContext::getConnection() should return the PDO connection
+            $lastId = $this->db->getConnection()->lastInsertId();
+            return $lastId ? (int)$lastId : null; // Ensure it's an int or null
+        }
+        return null;
+    }
+}
+?>


### PR DESCRIPTION
This commit implements Phase 3 of the architectural refactoring, introducing a service layer to separate business logic from controllers, initially for the accounts functionality.

Key changes:
- Created new directories: `app/Interfaces/Service/` and `app/Service/`.
- Defined `App\Interfaces\Service\IAccountService` interface with methods for account operations (`getAllAccounts`, `getAccountById`, `createAccount`).
- Implemented `App\Service\AccountService`, which implements `IAccountService` and encapsulates database interactions for accounts using `App\Persistence\DbContext`.
- Refactored `App\Http\Api\AccountsController`:
    - Constructor now injects `IAccountService`.
    - Controller methods now call the `AccountService` to handle business logic and data access, instead of directly using `DbContext`.
- Updated `App\Http\ApiRouter` to instantiate `AccountService` (with its `DbContext` dependency) and inject it into `AccountsController`.

This change improves separation of concerns, making the codebase more modular, testable, and maintainable.